### PR TITLE
C++ support in Clang monitoring

### DIFF
--- a/news-bot.iml
+++ b/news-bot.iml
@@ -82,7 +82,7 @@
     <orderEntry type="library" name="Leiningen: org.apache.httpcomponents/httpmime:4.5" level="project" />
     <orderEntry type="library" name="Leiningen: org.bouncycastle/bcpkix-jdk15on:1.54" level="project" />
     <orderEntry type="library" name="Leiningen: org.bouncycastle/bcprov-jdk15on:1.54" level="project" />
-    <orderEntry type="library" name="Leiningen: org.clojure/clojure:1.10.0" level="project" />
+    <orderEntry type="library" name="Leiningen: org.clojure/clojure:1.10.1" level="project" />
     <orderEntry type="library" name="Leiningen: org.clojure/clojurescript:1.9.293" level="project" />
     <orderEntry type="library" name="Leiningen: org.clojure/core.async:0.4.490" level="project" />
     <orderEntry type="library" name="Leiningen: org.clojure/core.cache:0.6.5" level="project" />

--- a/src/news_bot/publisher.clj
+++ b/src/news_bot/publisher.clj
@@ -5,6 +5,7 @@
             [news-bot.sources.overload :as overload]
             [news-bot.sources.boost :as boost]
             [news-bot.sources.cmake :as cmake]
+            [news-bot.sources.clang-features :as clang-features]
             [news-bot.persistence :as p]
             [news-bot.sources.interface :as sources]
             [taoensso.timbre :as log]))
@@ -48,7 +49,8 @@
     (publish-so-update bucket dp on-date))
   (publish-update bucket overload/get-data-provider)
   (publish-update bucket cmake/get-data-provider)
-  (publish-update bucket boost/get-data-provider))
+  (publish-update bucket boost/get-data-provider)
+  (publish-update bucket clang-features/get-data-provider))
 
 ;(try
 ;  (t/post-updates so-news-reader)

--- a/src/news_bot/sources/clang_features.clj
+++ b/src/news_bot/sources/clang_features.clj
@@ -1,0 +1,95 @@
+(ns news-bot.sources.clang-features
+  (:require [news-bot.sources.common-dp :as common-dp]
+            [hickory.select :as hs]
+            [clojure.string :as str]
+            [news-bot.sources.interface :as i]
+            [clojure.spec.alpha :as s]))
+
+
+(def clang-cxx-status-page "https://clang.llvm.org/cxx_status.html")
+(def cxx-20-table-nr 3)
+
+;(spit "cxx_status.html" (:body (http/get clang-cxx-status-page)))
+
+(defn- join-content [content]
+  (str/join "" (keep #(if-let [rec (:content %)]
+                        (first rec)
+                        %) (:content content))))
+
+(defn extract-content [content]
+  (into []
+        (keep #(if (:content %)
+                 (join-content %))
+              content)))
+
+(defn get-rows-count [record]
+  (if-let [val (first (keep #(get-in % [:attrs :rowspan])
+                            record))]
+    (read-string val)
+    1))
+
+(defn extract-url [record]
+  (first (keep #(if-let [content (:content %)]
+                  (get-in (first content) [:attrs :href]))
+               record)))
+
+(defn load-tables [page]
+  (hs/select (hs/child (hs/tag :tbody)) page))
+
+(defn process-record [record]
+  (let [content (extract-content record)]
+    (if-not (empty? content)
+      [content (extract-url record) (get-rows-count record)])))
+
+(defn- extract-records [table]
+  (let [preparsed (keep (fn [elem]
+                          (let [rec (process-record (:content elem))]
+                            (if-not (empty? rec)
+                              rec))) (:content table))]
+    (reduce (fn [l [[_ doc impl :as descr] url count]]
+              (if (= count 1)
+                (let [[[header_prev _ impl_prev] _ count_prev] (last l)
+                      count_prev (or count_prev 1)]
+                  (if (> count_prev 1)
+                    (conj l [[header_prev doc (or impl impl_prev)] url (dec count_prev)])
+                    (conj l [descr url count])))
+                (conj l [descr url count])))
+            [] preparsed)))
+
+(defn process-table [table]
+  (let [parsed (extract-records table)]
+    (map (fn [[[header proposal ver] url _]]
+           {:id    proposal
+            :title (format "%s: %s is available since %s" proposal header ver)
+            :link  url
+            :tags  ["c++" "c++20" "clang" proposal]})
+         (filter (fn fn [[[_ _ ver] _ _]]
+                   (re-find #"^Clang.*" (or ver ""))) parsed))))
+
+(defn parse-versions [page]
+  (process-table
+    (nth (load-tables page) cxx-20-table-nr)))
+
+(defrecord ClangCxxDataProvider [already-posted] i/DataProvider
+  (load-news [_]
+    (let [features (parse-versions (common-dp/load-page clang-cxx-status-page))]
+      (keep #(if-not (contains? already-posted (:id %))
+               %) features)))
+  (id [_] :clang-cxx))
+
+(defn get-data-provider
+  ([]
+   {:post [(s/valid? ::i/data-provider %)]}
+   (ClangCxxDataProvider. #{}))
+  ([already-posted]
+   {:post [(s/valid? ::i/data-provider %)]}
+   (ClangCxxDataProvider. (if (not-empty already-posted)
+                            already-posted
+                            #{}))))
+
+;(def dp (get-data-provider #{"P0482R6" "P0722R3" "P0683R1"}))
+;
+;(try
+;  (i/load-news dp)
+;  (catch Exception e
+;    (println e)))

--- a/test/data/compiler_status/cxx_status.html
+++ b/test/data/compiler_status/cxx_status.html
@@ -1,0 +1,1263 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+  <title>Clang - C++17, C++14, C++11 and C++98 Status</title>
+  <link type="text/css" rel="stylesheet" href="menu.css">
+  <link type="text/css" rel="stylesheet" href="content.css">
+  <style type="text/css">
+    .none { background-color: #FFCCCC }
+    .partial { background-color: #FFE0B0 }
+    .svn  { background-color: #FFFF99 }
+    .full { background-color: #CCFF99 }
+    .na { background-color: #DDDDDD }
+    :target { background-color: #FFFFBB; outline: #DDDD55 solid thin; }
+    th { background-color: #FFDDAA }
+    td { vertical-align: middle }
+    tt { white-space: nowrap }
+  </style>
+</head>
+<body>
+
+<div id="menu">
+  <div>
+    <a href="http://llvm.org/">LLVM Home</a>
+  </div>
+
+  <div class="submenu">
+    <label>Clang Info</label>
+    <a href="http://llvm.org/releases/download.html">Download</a>
+    <a href="/index.html">About</a>
+    <a href="/features.html">Features</a>
+    <a href="/comparison.html">Comparisons</a>
+    <a href="/related.html">Related Projects</a>
+    <a href="/docs/UsersManual.html">User's Manual</a>
+    <a href="/compatibility.html">Language&nbsp;Compatibility</a>
+    <a href="/docs/LanguageExtensions.html">Language&nbsp;Extensions</a>
+    <a href="/cxx_status.html">C++ Status</a>
+  </div>
+
+  <div class="submenu">
+    <label>Clang Development</label>
+    <a href="/get_started.html">Get&nbsp;Started</a>
+    <a href="/get_involved.html">Get&nbsp;Involved</a>
+    <a href="/OpenProjects.html">Open&nbsp;Projects</a>
+    <a href="/docs/InternalsManual.html">Clang&nbsp;Internals</a>
+    <a href="/hacking.html">Hacking on Clang</a>
+  </div>
+
+  <div class="submenu">
+    <label>Clang Tools</label>
+    <a href="http://clang-analyzer.llvm.org">Automatic Bug-Finding</a>
+    <a href="/docs/Tooling.html">Writing Clang Tools</a>
+  </div>
+
+  <div class="submenu">
+    <label>Communication</label>
+    <a href="http://lists.llvm.org/mailman/listinfo/cfe-users">cfe-users List</a>
+    <a href="http://lists.llvm.org/mailman/listinfo/cfe-dev">cfe-dev List</a>
+    <a href="http://lists.llvm.org/mailman/listinfo/cfe-commits">cfe-commits List</a>
+    <a href="https://bugs.llvm.org/">Bug Reports</a>
+    <a href="http://planet.clang.org/">Planet Clang</a>
+    <a href="irc://irc.oftc.net/llvm">IRC: irc.oftc.net#llvm</a>
+  </div>
+
+  <div class="submenu">
+    <label>The Code</label>
+    <a href="/get_started.html#build">Check Out Sources</a>
+    <a href="https://github.com/llvm/llvm-project/tree/master/clang/">Browse Sources</a>
+    <a href="http://clang.llvm.org/doxygen/">doxygen</a>
+  </div>
+
+  <div class="submenu">
+    <label>Quick Links</label>
+    <a href="http://llvm.org/reports/coverage/">Testing Coverage</a>
+  </div>
+
+  <div class="submenu">
+    <label>Clang Events</label>
+    <a href="http://llvm.org/devmtg/">LLVM Meeting</a>
+  </div>
+
+</div>
+
+
+<div id="content">
+
+<!--*************************************************************************-->
+<h1>C++ Support in Clang</h1>
+<!--*************************************************************************-->
+<p>Last updated: $Date: 2019-06-20 13:44:45 -0700 (Thu, 20 Jun 2019) $</p>
+
+<p>Clang fully implements all published ISO C++ standards (<a
+href="#cxx98">C++98 / C++03</a>, <a
+href="#cxx11">C++11</a>, and <a
+href="#cxx14">C++14</a>), and most of the upcoming <a
+href="#cxx17">C++17</a> standard.
+
+<p>The Clang community is continually striving to improve C++ standards
+compliance between releases by submitting and tracking <a
+href="cxx_dr_status.html">C++ Defect Reports</a> and implementing resolutions
+as they become available.</p>
+
+<p>Experimental work is also under way to implement <a href="#ts">C++ Technical
+Specifications</a> that will help drive the future of the C++ programming
+language.</p>
+
+<p>The <a href="https://bugs.llvm.org/">LLVM bug tracker</a> contains Clang
+C++ components that track known bugs with Clang's language conformance in
+each language mode.</p>
+
+<h2 id="cxx98">C++98 implementation status</h2>
+
+<p>Clang implements all of the ISO C++ 1998 standard
+  (including the defects addressed in the ISO C++ 2003 standard)
+  except for <tt>export</tt> (which was removed in C++11).
+
+<h2 id="cxx11">C++11 implementation status</h2>
+
+<p>Clang 3.3 and later implement all of the <a
+  href="http://www.iso.org/standard/50372.html">ISO
+  C++ 2011 standard</a>.
+
+<p>By default, Clang builds C++ code according to the C++98 standard, with many
+C++11 features accepted as extensions. You can use Clang in C++11 mode with the
+<code>-std=c++11</code> option. Clang's C++11 mode can be used
+with <a href="http://libcxx.llvm.org/">libc++</a> or with gcc's libstdc++.
+
+<details>
+<summary>List of features and minimum Clang version with support</summary>
+
+<table width="689" border="1" cellspacing="0">
+ <tr>
+    <th>Language Feature</th>
+    <th>C++11 Proposal</th>
+    <th>Available in Clang?</th>
+ </tr>
+     <tr>
+      <td>Rvalue references</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2006/n2118.html">N2118</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>&nbsp;&nbsp;&nbsp;&nbsp;Rvalue references for <code>*this</code></td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2439.htm">N2439</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>Initialization of class objects by rvalues</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2004/n1610.html">N1610</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>Non-static data member initializers</td>
+      <td><a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2008/n2756.htm">N2756</a></td>
+      <td class="full" align="center">Clang 3.0</td>
+    </tr>
+    <tr>
+      <td>Variadic templates</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2242.pdf">N2242</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>&nbsp;&nbsp;&nbsp;&nbsp;Extending variadic template template parameters</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2555.pdf">N2555</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td rowspan="2">Initializer lists</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2672.htm">N2672</a></td>
+      <td class="full" align="center">Clang 3.1</td>
+    </tr>
+      <tr> <!-- from Kona 2019-->
+        <td><a href="http://wg21.link/p1009r2">P1009R2</a> (<a href="#dr">DR</a>)</td>
+        <td class="svn" align="center">SVN</td>
+      </tr>
+    <tr>
+      <td>Static assertions</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2004/n1720.html">N1720</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td><code>auto</code>-typed variables</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2006/n1984.pdf">N1984</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>&nbsp;&nbsp;&nbsp;&nbsp;Multi-declarator <code>auto</code></td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2004/n1737.pdf">N1737</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>&nbsp;&nbsp;&nbsp;&nbsp;Removal of auto as a storage-class specifier</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2546.htm">N2546</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>&nbsp;&nbsp;&nbsp;&nbsp;New function declarator syntax</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2541.htm">N2541</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td rowspan="2">Lambda expressions</td>
+      <td><a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2009/n2927.pdf">N2927</a></td>
+      <td class="full" align="center">Clang 3.1</td>
+    </tr>
+      <tr>
+        <!-- from Albuquerque 2017 -->
+        <td><a href="http://wg21.link/p0588r1">P0588R1</a> (<a href="#dr">DR</a>)</td>
+        <td class="none" align="center">No</td>
+      </tr>
+    <tr>
+      <td>Declared type of an expression</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2343.pdf">N2343</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>&nbsp;&nbsp;&nbsp;&nbsp;Incomplete return types</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2011/n3276.pdf">N3276</a></td>
+      <td class="full" align="center">Clang 3.1</td>
+    </tr>
+    <tr>
+      <td>Right angle brackets</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2005/n1757.html">N1757</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>Default template arguments for function templates</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#226">DR226</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>Solving the SFINAE problem for expressions</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2634.html">DR339</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>Alias templates</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2258.pdf">N2258</a></td>
+      <td class="full" align="center">Clang 3.0</td>
+    </tr>
+    <tr>
+      <td>Extern templates</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2006/n1987.htm">N1987</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>Null pointer constant</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2431.pdf">N2431</a></td>
+      <td class="full" align="center">Clang 3.0</td>
+    </tr>
+    <tr>
+      <td>Strongly-typed enums</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2347.pdf">N2347</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>Forward declarations for enums</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2764.pdf">N2764</a>
+      <br><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#1206">DR1206</a></td>
+      <td class="full" align="center">Clang 3.1</td>
+    </tr>
+    <tr>
+      <td>Standardized attribute syntax</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2761.pdf">N2761</a></td>
+      <td class="full" align="center">Clang 3.3 <a href="#n2761">(1)</a></td>
+    </tr>
+    <tr>
+      <td rowspan="2">Generalized constant expressions</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2235.pdf">N2235</a></td>
+      <td class="full" align="center">Clang 3.1</td>
+    </tr>
+      <tr>
+        <!-- from Albuquerque 2017 -->
+        <td><a href="http://wg21.link/p0859r0">P0859R0</a> (<a href="#dr">DR</a>)</td>
+        <td class="full" align="center">Clang 8</td>
+      </tr>
+    <tr>
+      <td>Alignment support</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2341.pdf">N2341</a></td>
+      <td class="full" align="center">Clang 3.3</td>
+    </tr>
+    <tr>
+      <td>Conditionally-support behavior</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2004/n1627.pdf">N1627</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>Changing undefined behavior into diagnosable errors</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2004/n1727.pdf">N1727</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>Delegating constructors</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2006/n1986.pdf">N1986</a></td>
+      <td class="full" align="center">Clang 3.0</td>
+    </tr>
+    <tr>
+      <td rowspan="2">Inheriting constructors</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2540.htm">N2540</a></td>
+      <td class="full" align="center">Clang 3.3</td>
+    </tr>
+      <tr>
+        <!-- from Kona 2015 -->
+        <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0136r1.html">P0136R1</a> (<a href="#dr">DR</a>)</td>
+        <td class="full" align="center">Clang 3.9</td>
+      </tr>
+    <tr>
+      <td>Explicit conversion operators</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2437.pdf">N2437</a></td>
+      <td class="full" align="center">Clang 3.0</td>
+    </tr>
+    <tr>
+      <td>New character types</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2249.html">N2249</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>Unicode string literals</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2442.htm">N2442</a></td>
+      <td class="full" align="center">Clang 3.0</td>
+    </tr>
+    <tr>
+      <td>Raw string literals</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2442.htm">N2442</a></td>
+      <td class="full" align="center">Clang 3.0</td>
+    </tr>
+    <tr>
+      <td>Universal character names in literals</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2170.html">N2170</a></td>
+      <td class="full" align="center">Clang 3.1</td>
+    </tr>
+    <tr>
+      <td>User-defined literals</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2765.pdf">N2765</a></td>
+      <td class="full" align="center">Clang 3.1</td>
+    </tr>
+    <tr>
+      <td>Standard Layout Types</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2342.htm">N2342</a></td>
+      <td class="full" align="center">Clang 3.0</td>
+    </tr>
+    <tr>
+      <td rowspan="2">Defaulted functions</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2346.htm">N2346</a></td>
+      <td class="full" align="center">Clang 3.0</td>
+    </tr>
+      <tr> <!-- from Kona 2019-->
+        <td><a href="http://wg21.link/p1286r2">P1286R2</a> (<a href="#dr">DR</a>)</td>
+        <td class="svn" align="center">SVN</td>
+      </tr>
+    <tr>
+      <td>Deleted functions</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2346.htm">N2346</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>Extended friend declarations</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2005/n1791.pdf">N1791</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>Extending <code>sizeof</code></td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2253.html">N2253</a>
+      <br><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#850">DR850</a></td>
+      <td class="full" align="center">Clang 3.1</td>
+    </tr>
+    <tr>
+      <td>Inline namespaces</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2535.htm">N2535</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>Unrestricted unions</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2544.pdf">N2544</a></td>
+      <td class="full" align="center">Clang 3.1</td>
+    </tr>
+    <tr>
+      <td>Local and unnamed types as template arguments</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2657.htm">N2657</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td rowspan="2">Range-based for</td>
+      <td><a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2009/n2930.html">N2930</a></td>
+      <td class="full" align="center">Clang 3.0</td>
+    </tr>
+      <tr>
+        <!-- from Jacksonville 2018 -->
+        <td><a href="http://wg21.link/p0962r1">P0962R1</a> (<a href="#dr">DR</a>)</td>
+        <td class="full" align="center">Clang 8</td>
+      </tr>
+    <tr>
+      <td>Explicit virtual overrides</td>
+      <td><a href="http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2009/n2928.htm">N2928</a>
+      <br><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2010/n3206.htm">N3206</a>
+      <br><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2011/n3272.htm">N3272</a></td>
+      <td class="full" align="center">Clang 3.0</td>
+    </tr>
+    <tr>
+      <td>Minimal support for garbage collection and reachability-based leak detection</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2670.htm">N2670</a></td>
+      <td class="na" align="center">N/A <a href="#n2670">(2)</a></td>
+    </tr>
+    <tr>
+      <td>Allowing move constructors to throw [noexcept]</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2010/n3050.html">N3050</a></td>
+      <td class="full" align="center">Clang 3.0</td>
+    </tr>
+    <tr>
+      <td>Defining move special member functions</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2010/n3053.html">N3053</a></td>
+      <td class="full" align="center">Clang 3.0</td>
+    </tr>
+
+    <tr class="separator">
+      <th align="center" colspan="3">Concurrency</th>
+    </tr>
+    <tr>
+      <td>Sequence points</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2239.html">N2239</a></td>
+      <td class="full" align="center">Clang 3.3</td>
+    </tr>
+    <tr>
+      <td>Atomic operations</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2427.html">N2427</a></td>
+      <td class="full" align="center">Clang 3.1</td>
+    </tr>
+    <tr>
+      <td>Strong Compare and Exchange</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2748.html">N2748</a></td>
+      <td class="full" align="center">Clang 3.1 <a href="#n2748">(3)</a></td>
+    </tr>
+    <tr>
+      <td>Bidirectional Fences</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2752.htm">N2752</a></td>
+      <td class="full" align="center">Clang 3.1</td>
+    </tr>
+
+    <tr>
+      <td>Memory model</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2429.htm">N2429</a></td>
+      <td class="full" align="center">Clang 3.2</td>
+    </tr>
+    <tr>
+      <td>Data-dependency ordering: atomics and memory model</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2664.htm">N2664</a></td>
+      <td class="full" align="center">Clang 3.2 <a href="#n2664">(4)</a></td>
+    </tr>
+    <tr>
+      <td>Propagating exceptions</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2179.html">N2179</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>Allow atomics use in signal handlers</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2547.htm">N2547</a></td>
+      <td class="full" align="center">Clang 3.1</td>
+    </tr>
+    <tr>
+      <td>Thread-local storage</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2659.htm">N2659</a></td>
+      <td class="full" align="center">Clang 3.3 <a href="#n2659">(5)</a></td>
+    </tr>
+    <tr>
+      <td>Dynamic initialization and destruction with concurrency</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2660.htm">N2660</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+
+    <tr class="separator">
+      <th align="center" colspan="3">C99 Features in C++11</th>
+    </tr>
+    <tr>
+      <td><code>__func__</code> predefined identifier</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2340.htm">N2340</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>C99 preprocessor</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2004/n1653.htm">N1653</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td><code>long long</code></td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2005/n1811.pdf">N1811</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>Extended integral types</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2006/n1988.pdf">N1988</a></td>
+      <td class="na" align="center">N/A <a href="#n1988">(6)</a></td>
+    </tr>
+</table>
+
+<p>
+<span id="n2761">(1): The <code>[[carries_dependency]]</code> attribute
+has no effect.</span><br>
+<span id="n2670">(2): No compiler changes are required for an implementation
+such as Clang that does not provide garbage collection.</span><br>
+<span id="n2748">(3): All compare-exchange operations are emitted as
+strong compare-exchanges.</span><br>
+<span id="n2664">(4): <code>memory_order_consume</code> is lowered to
+<code>memory_order_acquire</code>.</span><br>
+<span id="n2659">(5): <code>thread_local</code> support
+requires a C++ runtime library providing <code>__cxa_thread_atexit</code>, such
+as <a href="http://libcxxabi.llvm.org">libc++abi</a> 3.6 or later,
+or libsupc++ 4.8 or later.</span><br>
+<span id="n1988">(6): No compiler changes are required for an implementation
+such as Clang that does not provide any extended integer types.
+<code>__int128</code> is not treated as an extended integer type,
+because changing <code>intmax_t</code> would be an ABI-incompatible
+change.</span>
+</p>
+</details>
+
+<h2 id="cxx14">C++14 implementation status</h2>
+
+<p>Clang 3.4 and later implement all of the <a
+    href="http://www.iso.org/standard/64029.html">ISO
+    C++ 2014 standard</a>.
+
+<p>You can use Clang in C++14 mode with the <code>-std=c++14</code> option
+(use <code>-std=c++1y</code> in Clang 3.4 and earlier).</p>
+
+<details>
+<summary>List of features and minimum Clang version with support</summary>
+
+<table width="689" border="1" cellspacing="0">
+ <tr>
+    <th>Language Feature</th>
+    <th>C++14 Proposal</th>
+    <th>Available in Clang?</th>
+ </tr>
+    <tr>
+      <td>Tweak to certain C++ contextual conversions</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3323.pdf">N3323</a></td>
+      <td class="full" align="center">Clang 3.4</td>
+    </tr>
+    <tr>
+      <td>Binary literals</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3472.pdf">N3472</a></td>
+      <td class="full" align="center">Clang 2.9</td>
+    </tr>
+    <tr>
+      <td>decltype(auto)</td>
+      <td rowspan=2 style="vertical-align:middle"><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3638.html">N3638</a></td>
+      <td class="full" align="center">Clang 3.3</td>
+    </tr>
+    <tr>
+      <td>Return type deduction for normal functions</td>
+      <td class="full" align="center">Clang 3.4</td>
+    </tr>
+    <tr>
+      <td>Initialized lambda captures</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3648.html">N3648</a></td>
+      <td class="full" align="center">Clang 3.4</td>
+    </tr>
+    <tr>
+      <td>Generic lambdas</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3649.html">N3649</a></td>
+      <td class="full" align="center">Clang 3.4</td>
+    </tr>
+    <tr>
+      <td>Variable templates</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3651.pdf">N3651</a></td>
+      <td class="full" align="center">Clang 3.4</td>
+    </tr>
+    <tr>
+      <td>Relaxing requirements on constexpr functions</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3652.html">N3652</a></td>
+      <td class="full" align="center">Clang 3.4</td>
+    </tr>
+    <tr>
+      <td>Member initializers and aggregates</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3653.html">N3653</a></td>
+      <td class="full" align="center">Clang 3.3</td>
+    </tr>
+    <tr>
+      <td>Clarifying memory allocation</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3664.html">N3664</a></td>
+      <td class="full" align="center">Clang 3.4</td>
+    </tr>
+    <tr>
+      <td><tt>[[deprecated]]</tt> attribute</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3760.html">N3760</a></td>
+      <td class="full" align="center">Clang 3.4</td>
+    </tr>
+    <tr>
+      <td>Single quotation mark as digit separator</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3781.pdf">N3781</a></td>
+      <td class="full" align="center">Clang 3.4</td>
+    </tr>
+    <tr>
+      <td>C++ Sized Deallocation</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3778.html">N3778</a></td>
+      <td class="full" align="center">Clang 3.4 <a href="#n3778">(7)</a></td>
+    </tr>
+</table>
+
+<p>
+<span id="n3778">(7): In Clang 3.7 and later, sized deallocation is only enabled
+if the user passes the <code>-fsized-deallocation</code> flag. The user must
+supply definitions of the sized deallocation functions, either by providing them
+explicitly or by using a C++ standard library that does. <code>libstdc++</code>
+added these functions in version 5.0, and <code>libc++</code> added them in
+version 3.7.
+</span>
+</p>
+</details>
+
+<h2 id="cxx17">C++17 implementation status</h2>
+
+<p>Clang 5 and later implement all the features of the
+<a href="https://www.iso.org/standard/68564.html">ISO C++ 2017 standard</a>.
+
+<p>You can use Clang in C++17 mode with the <code>-std=c++17</code> option
+(use <code>-std=c++1z</code> in Clang 4 and earlier).</p>
+
+<details open>
+<summary>List of features and minimum Clang version with support</summary>
+
+<table width="689" border="1" cellspacing="0">
+ <tr>
+    <th>Language Feature</th>
+    <th>C++17 Proposal</th>
+    <th>Available in Clang?</th>
+ </tr>
+    <!-- Issaquah 2014 papers -->
+    <tr>
+      <td><tt>static_assert</tt> with no message</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n3928.pdf">N3928</a></td>
+      <td class="full" align="center">Clang 3.5</td>
+    </tr>
+    <!-- Rapperswil papers -->
+    <tr>
+      <td>Disabling trigraph expansion by default</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4086.html">N4086</a></td>
+      <td class="full" align="center">Clang 3.5</td>
+    </tr>
+    <!--
+    <tr>
+      <td rowspan="2">Terse range-based for loops (removed from C++17)</td>
+      <td rowspan="2"><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n3994.htm">N3994</a></td>
+      <td class="none" align="center">Clang 3.5: Yes</td>
+    </tr>
+    <tr>
+      <td class="svn" align="center">SVN: No</td>
+    </tr>
+    -->
+    <tr>
+      <td><tt>typename</tt> in a template template parameter</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4051.html">N4051</a></td>
+      <td class="full" align="center">Clang 3.5</td>
+    </tr>
+    <tr>
+      <td>New <tt>auto</tt> rules for direct-list-initialization
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n3922.html">N3922</a></td>
+      <td class="full" align="center">Clang 3.8 <a href="#n3922">(8)</a></td>
+    </tr>
+    <!-- Urbana papers -->
+    <tr>
+      <td rowspan="2">Fold expressions</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4295.html">N4295</a></td>
+      <td class="full" align="center">Clang 3.6</td>
+    </tr>
+      <tr> <!-- from Jacksonville -->
+        <td><a href="http://wg21.link/p0036r0">P0036R0</a></td>
+        <td class="full" align="center">Clang 3.9</td>
+      </tr>
+    <tr>
+      <td><tt>u8</tt> character literals</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4267.html">N4267</a></td>
+      <td class="full" align="center">Clang 3.6</td>
+    </tr>
+    <tr>
+      <td>Nested namespace definition</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4230.html">N4230</a></td>
+      <td class="full" align="center">Clang 3.6</td>
+    </tr>
+    <tr>
+      <td>Attributes for namespaces and enumerators</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4266.html">N4266</a></td>
+      <td class="full" align="center">Clang 3.6</td>
+    </tr>
+    <tr>
+      <td>Allow constant evaluation for all non-type template arguments</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4268.html">N4268</a></td>
+      <td class="full" align="center">Clang 3.6</td>
+    </tr>
+    <!-- Kona papers -->
+    <tr>
+      <td>Remove deprecated <tt>register</tt> storage class</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0001r1.html">P0001R1</a></td>
+      <td class="full" align="center">Clang 3.8</td>
+    </tr>
+    <tr>
+      <td>Remove deprecated <tt>bool</tt> increment</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0002r1.html">P0002R1</a></td>
+      <td class="full" align="center">Clang 3.8</td>
+    </tr>
+    <tr>
+      <td>Make exception specifications part of the type system</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0012r1.html">P0012R1</a></td>
+      <td class="full" align="center">Clang 4</td>
+    </tr>
+    <tr>
+      <td><tt>__has_include</tt> in preprocessor conditionals</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0061.html">P0061R1</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <!-- Jacksonville papers -->
+    <tr>
+      <td><tt>[[fallthrough]]</tt> attribute</td>
+      <td><a href="http://wg21.link/p0188r1">P0188R1</a></td>
+      <td class="full" align="center">Clang 3.9</td>
+    </tr>
+    <tr>
+      <td><tt>[[nodiscard]]</tt> attribute</td>
+      <td><a href="http://wg21.link/p0189r1">P0189R1</a></td>
+      <td class="full" align="center">Clang 3.9</td>
+    </tr>
+    <tr>
+      <td><tt>[[maybe_unused]]</tt> attribute</td>
+      <td><a href="http://wg21.link/p0212r1">P0212R1</a></td>
+      <td class="full" align="center">Clang 3.9</td>
+    </tr>
+    <tr>
+      <td>Aggregate initialization of classes with base classes</td>
+      <td><a href="http://wg21.link/p0017r1">P0017R1</a></td>
+      <td class="full" align="center">Clang 3.9</td>
+    </tr>
+    <tr>
+      <td><tt>constexpr</tt> lambda expressions</td>
+      <td><a href="http://wg21.link/p0170r1">P0170R1</a></td>
+      <td class="full" align="center">Clang 5</td>
+    </tr>
+    <tr>
+      <td>Differing <tt>begin</tt> and <tt>end</tt> types in range-based <tt>for</tt></td>
+      <td><a href="http://wg21.link/p0184r0">P0184R0</a></td>
+      <td class="full" align="center">Clang 3.9</td>
+    </tr>
+    <tr>
+      <td>Lambda capture of <tt>*this</tt></td>
+      <td><a href="http://wg21.link/p0018r3">P0018R3</a></td>
+      <td class="full" align="center">Clang 3.9</td>
+    </tr>
+    <tr>
+      <td>Direct-list-initialization of <tt>enum</tt>s</td>
+      <td><a href="http://wg21.link/p0138r2">P0138R2</a></td>
+      <td class="full" align="center">Clang 3.9</td>
+    </tr>
+    <tr>
+      <td>Hexadecimal floating-point literals</td>
+      <td><a href="http://wg21.link/p0245r1">P0245R1</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <!-- Oulu papers -->
+    <tr>
+      <td>Using attribute namespaces without repetition</td>
+      <td><a href="http://wg21.link/p0028r4">P0028R4</a></td>
+      <td class="full" align="center">Clang 3.9</td>
+    </tr>
+    <tr>
+      <td>Dynamic memory allocation for over-aligned data</td>
+      <td><a href="http://wg21.link/p0035r4">P0035R4</a></td>
+      <td class="full" align="center">Clang 4</td>
+    </tr>
+    <tr>
+      <td rowspan="4">Template argument deduction for class templates</td>
+      <td><a href="http://wg21.link/p0091r3">P0091R3</a></td>
+      <td rowspan="2" class="full" align="center">Clang 5</td>
+    </tr>
+      <tr> <!-- from Issaquah -->
+        <td><a href="http://wg21.link/p0512r0">P0512R0</a></td>
+      </tr>
+      <tr>
+        <!-- from Kona 2017 -->
+        <td><a href="http://wg21.link/p0620r1">P0620R0</a> (<a href="#dr">DR</a>)</td>
+        <td class="full" align="center">Clang 7</td>
+      </tr>
+      <tr>
+        <!-- from Toronto 2017 -->
+        <td><a href="http://wg21.link/p0702r1">P0702R1</a> (<a href="#dr">DR</a>)</td>
+        <td class="full" align="center">Clang 6</td>
+      </tr>
+    <tr>
+      <td>Non-type template parameters with <tt>auto</tt> type</td>
+      <td><a href="http://wg21.link/p0127r2">P0127R2</a></td>
+      <td class="full" align="center">Clang 4</td>
+    </tr>
+    <tr>
+      <td>Guaranteed copy elision</td>
+      <td><a href="http://wg21.link/p0135r1">P0135R1</a></td>
+      <td class="full" align="center">Clang 4</td>
+    </tr>
+    <tr>
+      <td rowspan=2>Stricter expression evaluation order</td>
+      <td><a href="http://wg21.link/p0145r3">P0145R3</a></td>
+      <td class="full" align="center" rowspan=2>Clang 4 <a href="#p0145">(9)</a></td>
+    </tr>
+    <tr>
+      <td><a href="http://wg21.link/p0400r0">P0400R0</a></td>
+    </tr>
+    <tr>
+      <td>Requirement to ignore unknown attributes</td>
+      <td><a href="http://wg21.link/p0283r2">P0283R2</a></td>
+      <td class="full" align="center">Yes</td>
+    </tr>
+    <tr>
+      <td><tt>constexpr</tt> <em>if-statement</em>s</td>
+      <td><a href="http://wg21.link/p0292r2">P0292R2</a></td>
+      <td class="full" align="center">Clang 3.9</td>
+    </tr>
+    <tr>
+      <td>Inline variables</td>
+      <td><a href="http://wg21.link/p0386r2">P0386R2</a></td>
+      <td class="full" align="center">Clang 3.9</td>
+    </tr>
+    <tr>
+      <td rowspan="3">Structured bindings</td>
+      <td><a href="http://wg21.link/p0217r3">P0217R3</a></td>
+      <td class="full" align="center">Clang 4</td>
+    </tr>
+      <tr>
+        <!-- from Jacksonville 2018 -->
+        <td><a href="http://wg21.link/p0961r1">P0961R1</a> (<a href="#dr">DR</a>)</td>
+        <td class="full" align="center">Clang 8</td>
+      </tr>
+      <tr>
+        <!-- from Jacksonville 2018 -->
+        <td><a href="http://wg21.link/p0969r0">P0969R0</a> (<a href="#dr">DR</a>)</td>
+        <td class="full" align="center">Clang 8</td>
+      </tr>
+    <tr>
+      <td>Separate variable and condition for <tt>if</tt> and <tt>switch</tt></td>
+      <td><a href="http://wg21.link/p0305r1">P0305R1</a></td>
+      <td class="full" align="center">Clang 3.9</td>
+    </tr>
+    <!-- Issaquah 2016 papers -->
+    <tr>
+      <td>Matching template template parameters to compatible arguments</td>
+      <td><a href="http://wg21.link/p0522r0">P0522R0</a></td>
+      <td class="partial" align="center">Partial <a href="#p0522">(10)</a></td>
+    </tr>
+    <tr>
+      <td>Removing deprecated dynamic exception specifications</td>
+      <td><a href="http://wg21.link/p0003r5">P0003R5</a></td>
+      <td class="full" align="center">Clang 4</td>
+    </tr>
+    <tr>
+      <td>Pack expansions in <em>using-declarations</em></td>
+      <td><a href="http://wg21.link/p0195r2">P0195R2</a></td>
+      <td class="full" align="center">Clang 4</td>
+    </tr>
+</table>
+
+<p>
+<span id="n3922">(8): This is a backwards-incompatible change that is applied to
+all language versions that allow type deduction from <tt>auto</tt>
+(per the request of the C++ committee).
+In Clang 3.7, a warning is emitted for all cases that would change meaning.
+</span><br>
+<span id="p0145">(9): Under the MS ABI, function parameters are destroyed from
+left to right in the callee. As a result, function parameters in calls to
+<tt>operator&lt;&lt;</tt>, <tt>operator&gt;&gt;</tt>, <tt>operator-&gt;*</tt>,
+<tt>operator&amp;&amp;</tt>, <tt>operator||</tt>, and <tt>operator,</tt>
+functions using expression syntax are no longer guaranteed to be destroyed in
+reverse construction order in that ABI.
+</span><br>
+<span id="p0522">(10): Despite being the resolution to a Defect Report, this
+feature is disabled by default in all language versions, and can be enabled
+explicitly with the flag <tt>-frelaxed-template-template-args</tt> in Clang 4
+onwards.
+The change to the standard lacks a corresponding change for template partial
+ordering, resulting in ambiguity errors for reasonable and previously-valid
+code. This issue is expected to be rectified soon.
+</span>
+</p>
+</details>
+
+<h2 id="cxx20">C++2a implementation status</h2>
+
+<p>Clang has <b>experimental</b> support for some proposed features of
+the C++ standard following C++17, provisionally named C++2a.
+Note that support for these features may change or be removed without notice,
+as the draft C++2a standard evolves.
+
+<p>You can use Clang in C++2a mode with the <code>-std=c++2a</code> option.</p>
+
+<details open>
+<summary>List of features and minimum Clang version with support</summary>
+
+<table width="689" border="1" cellspacing="0">
+ <tr>
+    <th>Language Feature</th>
+    <th>C++2a Proposal</th>
+    <th>Available in Clang?</th>
+ </tr>
+    <!-- Toronto 2017 papers -->
+    <tr>
+      <td>Default member initializers for bit-fields</td>
+      <td><a href="http://wg21.link/p0683r1">P0683R1</a></td>
+      <td class="full" align="center">Clang 6</td>
+    </tr>
+    <tr>
+      <td><tt>const&amp;</tt>-qualified pointers to members</td>
+      <td><a href="http://wg21.link/p0704r1">P0704R1</a></td>
+      <td class="full" align="center">Clang 6</td>
+    </tr>
+    <tr>
+      <td>Allow <i>lambda-capture</i> <tt>[=, this]</tt></td>
+      <td><a href="http://wg21.link/p0409r2">P0409R2</a></td>
+      <td class="full" align="center">Clang 6</td>
+    </tr>
+    <tr>
+      <td rowspan="2"><tt>__VA_OPT__</tt> for preprocessor comma elision</td>
+      <td><a href="http://wg21.link/p0306r4">P0306R4</a></td>
+      <td class="full" align="center">Clang 6</td>
+    </tr>
+      <tr> <!-- from Rapperswil -->
+        <td><a href="http://wg21.link/p1042r1">P1042R1</a></td>
+        <td class="svn" align="center">SVN</td>
+      </tr>
+    <tr>
+      <td>Designated initializers</td>
+      <td><a href="http://wg21.link/p0329r4">P0329R4</a></td>
+      <td class="partial" align="center">Partial (extension)</td>
+    </tr>
+    <tr>
+      <td><i>template-parameter-list</i> for generic lambdas</td>
+      <td><a href="http://wg21.link/p0428r2">P0428R2</a></td>
+      <td class="svn" align="center">SVN</td>
+    </tr>
+    <tr id="p0734">
+      <td rowspan="4">Concepts</td>
+      <td><a href="http://wg21.link/p0734r0">P0734R0</a></td>
+      <td rowspan="4" class="none" align="center">No</td>
+    </tr>
+      <tr> <!-- from Albuquerque -->
+        <td><a href="http://wg21.link/p0857r0">P0857R0</a></td>
+      </tr>
+      <tr> <!-- from San Diego -->
+        <td><a href="http://wg21.link/p1084r2">P1084R2</a></td>
+      </tr>
+      <tr>
+        <td><a href="http://wg21.link/p1141r2">P1414R2</a></td>
+      </tr>
+    <!-- Albuquerque papers -->
+    <tr>
+      <td>Range-based for statements with initializer</td>
+      <td><a href="http://wg21.link/p0614r1">P0614R1</a></td>
+      <td class="full" align="center">Clang 8</td>
+    </tr>
+    <tr>
+      <td>ADL and function templates that are not visible</td>
+      <td><a href="http://wg21.link/p0846r0">P0846R0</a></td>
+      <td class="svn" align="center">SVN</td>
+    </tr>
+    <tr>
+      <td><tt>const</tt> mismatch with defaulted copy constructor</td>
+      <td><a href="http://wg21.link/p0641r2">P0641R2</a></td>
+      <td class="full" align="center">Clang 8</td>
+    </tr>
+    <tr>
+      <td rowspan="4">Consistent comparison (<tt>operator&lt;=&gt;</tt>)</td>
+      <td><a href="http://wg21.link/p0515r3">P0515R3</a></td>
+      <td rowspan="3" class="partial" align="center">Partial</td>
+    </tr>
+      <tr> <!-- from Jacksonville -->
+        <td><a href="http://wg21.link/p0905r1">P0905R1</a></td>
+      </tr>
+      <tr> <!-- from Rapperswil -->
+        <td><a href="http://wg21.link/p1120r0">P1120R0</a></td>
+      </tr>
+      <tr> <!-- from Kona 2019 -->
+        <td><a href="http://wg21.link/p1185r2">P1185R2</a></td>
+        <td class="none" align="center">No</td>
+      </tr>
+    <tr>
+      <td>Access checking on specializations</td>
+      <td><a href="http://wg21.link/p0692r1">P0692R1</a></td>
+      <td class="partial" align="center">Partial</td>
+    </tr>
+    <tr>
+      <td>Default constructible and assignable stateless lambdas</td>
+      <td><a href="http://wg21.link/p0624r2">P0624R2</a></td>
+      <td class="full" align="center">Clang 8</td>
+    </tr>
+    <tr>
+      <td>Lambdas in unevaluated contexts</td>
+      <td><a href="http://wg21.link/p0315r4">P0315R4</a></td>
+      <td class="none" align="center">No</td>
+    </tr>
+    <!-- Jacksonville papers -->
+    <tr>
+      <td><tt>[[no_unique_address]]</tt> attribute</td>
+      <td><a href="http://wg21.link/p0840r2">P0840R2</a></td>
+      <td class="svn" align="center">SVN</td>
+    </tr>
+    <tr>
+      <td><tt>[[likely]]</tt> and <tt>[[unlikely]]</tt> attributes</td>
+      <td><a href="http://wg21.link/p0479r5">P0479R5</a></td>
+      <td class="none" align="center">No</td>
+    </tr>
+    <tr>
+      <td><tt>typename</tt> optional in more contexts</td>
+      <td><a href="http://wg21.link/p0634r3">P0634R3</a></td>
+      <td class="none" align="center">No</td>
+    </tr>
+    <tr>
+      <td>Pack expansion in lambda <i>init-capture</i></td>
+      <td><a href="http://wg21.link/p0780r2">P0780R2</a></td>
+      <td class="svn" align="center">SVN</td>
+    </tr>
+    <!-- Rapperswil papers -->
+    <tr>
+      <td>Class types as non-type template parameters</td>
+      <td><a href="http://wg21.link/p0732r2">P0732R2</a></td>
+      <td class="none" align="center">No</td>
+    </tr>
+    <tr>
+      <td>Destroying operator delete</td>
+      <td><a href="http://wg21.link/p0722r3">P0722R3</a></td>
+      <td class="full" align="center">Clang 6</td>
+    </tr>
+    <tr>
+      <td rowspan=4>Relaxations of <tt>constexpr</tt> restrictions</td>
+      <td><a href="http://wg21.link/p1064r0">P1064R0</a></td>
+      <td class="svn" align="center">SVN</td>
+    </tr>
+      <tr> <!-- from San Diego -->
+        <td><a href="http://wg21.link/p1002r1">P1002R1</a></td>
+        <td class="full" align="center">Clang 8</td>
+      </tr>
+      <tr>
+        <td><a href="http://wg21.link/p1327r1">P1327R1</a></td>
+        <td rowspan="2" class="svn" align="center">SVN</td>
+      </tr>
+      <tr>
+        <td><a href="http://wg21.link/p1330r0">P1330R0</a></td>
+      </tr>
+    <tr>
+      <td>Prohibit aggregates with user-declared constructors</td>
+      <td><a href="http://wg21.link/p1008r1">P1008R1</a></td>
+      <td class="full" align="center">Clang 8</td>
+    </tr>
+    <tr>
+      <td rowspan="3">Contracts</td>
+      <td><a href="http://wg21.link/p0542r5">P0542R5</a></td>
+      <td rowspan="3" class="none" align="center">No</td>
+    </tr>
+      <tr> <!-- from San Diego -->
+        <td><a href="http://wg21.link/p1289r1">P1289R1</a></td>
+      </tr>
+      <tr> <!-- from Kona 2019-->
+        <td><a href="http://wg21.link/p1323r2">P1323R2</a></td>
+      </tr>
+    <tr>
+      <td>Feature test macros</td>
+      <td><a href="http://wg21.link/p0941r2">P0941R2</a></td>
+      <td class="full" align="center"><a href="#sd6">(see below)</a></td>
+    </tr>
+    <tr>
+      <td><tt>explicit(bool)</tt></td>
+      <td><a href="http://wg21.link/p0892r2">P0892R2</a></td>
+      <td class="svn" align="center">SVN</td>
+    </tr>
+    <!-- San Diego papers -->
+    <tr>
+      <td>Signed integers are two's complement</td>
+      <td><a href="http://wg21.link/p1236r1">P1236R1</a></td>
+      <td class="none" align="center">No</td>
+    </tr>
+    <tr>
+      <td><tt>char8_t</tt></td>
+      <td><a href="http://wg21.link/p0482r6">P0482R6</a></td>
+      <td class="full" align="center">Clang 7 <a href="#p0482">(11)</a></td>
+    </tr>
+    <tr>
+      <td>Immediate functions (<tt>consteval</tt>)</td>
+      <td><a href="http://wg21.link/p1073r3">P1073R3</a></td>
+      <td class="none" align="center">No</td>
+    </tr>
+    <tr>
+      <td><tt>std::is_constant_evaluated</tt></td>
+      <td><a href="http://wg21.link/p0595r2">P0595R2</a></td>
+      <td class="svn" align="center">SVN</td>
+    </tr>
+    <tr>
+      <td>Nested inline namespaces</td>
+      <td><a href="http://wg21.link/p1094r2">P1094R2</a></td>
+      <td class="full" align="center">Clang 8</td>
+    </tr>
+    <!-- Kona 2019 papers -->
+    <tr>
+      <td rowspan="2">Structured binding extensions</td>
+      <td><a href="http://wg21.link/p1091r3">P1091R3</a></td>
+      <td rowspan="2" class="partial" align="center">Partial</td>
+    </tr>
+      <tr>
+        <td><a href="http://wg21.link/p1381r1">P1381R1</a></td>
+      </tr>
+    <tr>
+      <td rowspan="2">Stronger Unicode requirements</td>
+      <td><a href="http://wg21.link/p1041r4">P1041R4</a></td>
+      <td rowspan="2" class="full" align="center">Yes</td>
+    </tr>
+      <tr>
+        <td><a href="http://wg21.link/p1139r2">P1139R2</a></td>
+      </tr>
+    <tr>
+      <td>Parenthesized initialization of aggregates</td>
+      <td><a href="http://wg21.link/p0960r3">P0960R3</a></td>
+      <td class="none" align="center">No</td>
+    </tr>
+    <tr>
+      <td>Modules</td>
+      <td><a href="http://wg21.link/p1103r3">P1103R3</a></td>
+      <td class="partial" align="center">Partial</td>
+    </tr>
+    <tr>
+      <td>Coroutines</td>
+      <td><a href="http://wg21.link/p0912r5">P0912R5</a></td>
+      <td class="partial" align="center">Partial</td>
+    </tr>
+</table>
+
+<p>
+<span id="p0482">(11): Prior to Clang 8, this feature is not enabled by
+<tt>-std=c++2a</tt>, but can be enabled with <tt>-fchar8_t</tt>.
+</span>
+</p>
+</details>
+
+<h2 id="dr">Defect reports</h2>
+
+<p>Clang generally aims to implement resolutions to Defect Reports (bug fixes
+against prior standards) retroactively, in all prior standard versions where
+the fix is meaningful. Significant Defect Report changes to language features
+after the publication of the relevant standard are marked (DR) in the above
+table.</p>
+
+<p>Clang also has a test suite for conformance to resolutions for issues on the
+<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_toc.html">C++ core issues list</a>,
+most of which are considered Defect Reports.
+<a href="cxx_dr_status.html">Implementation status for C++ core issues</a> based on
+that test suite is tracked on a separate page.</p>
+
+<h2 id="ts">Technical specifications and standing documents</h2>
+
+<p>ISO C++ also publishes a number of documents describing additional language
+and library features that are not part of standard C++.</p>
+
+<details open>
+<summary>List of features and minimum Clang version with support</summary>
+
+<table width="689" border="1" cellspacing="0">
+ <tr>
+    <th>Document</th>
+    <th>Latest draft</th>
+    <th>Compiler flag</th>
+    <th>Available in Clang?</th>
+ </tr>
+    <tr id="sd6">
+      <td rowspan="6">SD-6: SG10 feature test recommendations</td>
+      <td rowspan="6"><a href="http://isocpp.org/std/standing-documents/sd-6-sg10-feature-test-recommendations">SD-6</a></td>
+      <td rowspan="6">N/A</td>
+      <td class="full" align="center">
+        Clang 3.4 (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3745">N3745</a>)</br>
+      </td>
+    </tr>
+    <tr>
+      <td class="full" align="center">
+        Clang 3.6 (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4200">N4200</a>)</a>
+      </td>
+    </tr>
+    <tr>
+      <td class="full" align="center">
+        Clang 4 (<a href="http://wg21.link/p0096r3">P0096R3</a>)</a>
+      </td>
+    </tr>
+    <tr>
+      <td class="full" align="center">
+        Clang 5 (<a href="http://wg21.link/p0096r4">P0096R4</a>)</a>
+      </td>
+    </tr>
+    <tr>
+      <td class="full" align="center">
+        Clang 7 (<a href="http://wg21.link/p0096r5">P0096R5</a>)</a>
+      </td>
+    </tr>
+    <tr>
+      <td class="partial" align="center">
+        WIP (<a href="http://wg21.link/p1353r0">P1353R0</a>)
+      </td>
+    </tr>
+    <!-- FIXME: Implement latest recommendations.
+    <tr>
+      <td class="svn" align="center">
+        SVN (<a href="http://wg21.link/p0096r3">P0096R3</a>)</a>
+      </td>
+    </tr>
+    -->
+    <!-- No compiler support is known to be needed for:
+           * Concurrency TS
+           * Parallelism TS (v1, v2)
+           * Ranges TS
+           * Networking TS
+           * File System TS
+    -->
+    <tr>
+      <td>[TS] Concepts</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0121r0.pdf">P0121R0</a></td>
+      <td></td>
+      <td class="na" align="center">Superseded by <a href="#p0734">P0734R0</a></td>
+    </tr>
+    <tr>
+      <!-- track unimplemented Coroutines features: p0913r1 p0914r1 p1356r0 -->
+      <td rowspan="2">[TS] Coroutines</td>
+      <td rowspan="2"><a href="https://isocpp.org/files/papers/N4663.pdf">N4663</a></td>
+      <td><tt>-fcoroutines-ts<br>-stdlib=libc++</tt></td>
+      <td class="full" align="center">Clang 5</td>
+    </tr>
+    <tr>
+      <td><tt>-std=c++2a<br>-stdlib=libc++</tt></td>
+      <td class="na" align="center">Superseded by <a href="#p0912">P0912R5</a></td>
+    </tr>
+    <tr>
+      <td>[TS] Library Fundamentals, Version 1 (invocation type traits)</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4480.html">N4480</a></td>
+      <td>N/A</td>
+      <td class="none" align="center">No</td>
+    </tr>
+    <tr>
+      <td>[TS] Library Fundamentals, Version 2 (<tt>source_location</tt>)</td>
+     <td><a href="http://wg21.link/n4617">N4617</a></td>
+      <td>N/A</td>
+      <td class="none" align="center">No</td>
+    </tr>
+    <tr>
+      <td>[TS] Modules</td>
+      <td><a href="http://wg21.link/n4720">N4720</a></td>
+      <td><tt>-fmodules-ts</tt></td>
+      <td class="na" align="center">Superseded by <a href="#p1103">P1103R3</a></td>
+    </tr>
+    <tr>
+      <td>[DRAFT TS] Reflection</td>
+      <td><a href="http://wg21.link/n4746">N4746</a></td>
+      <td></td>
+      <td class="none" align="center">No</td>
+    </tr>
+    <tr>
+      <td>[TS] Transactional Memory</td>
+      <td><a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4514.pdf">N4514</a></td>
+      <td></td>
+      <td class="none" align="center">No</td>
+    </tr>
+</table>
+</details>
+
+</div>
+</body>
+</html>

--- a/test/news_bot/compiler_features.clj
+++ b/test/news_bot/compiler_features.clj
@@ -1,0 +1,76 @@
+(ns news-bot.compiler-features
+  (:require [clojure.test :refer :all]
+            [news-bot.test-utils :refer :all]
+            [news-bot.sources.clang-features :refer :all]
+            [news-bot.sources.interface :as i]
+            [clojure.set :as set]))
+
+(def content0 ["\n"
+               {:type :element, :attrs nil, :tag :td, :content ["Default member initializers for bit-fields"]}
+               "\n"
+               {:type    :element,
+                :attrs   nil,
+                :tag     :td,
+                :content [{:type :element, :attrs {:href "http://wg21.link/p0683r1"}, :tag :a, :content ["P0683R1"]}]}
+               "\n"
+               {:type :element, :attrs {:class "full", :align "center"}, :tag :td, :content ["Clang 6"]}
+               "\n"])
+
+(def content1 ["\n"
+               {:type    :element,
+                :attrs   nil,
+                :tag     :td,
+                :content [{:type :element, :attrs nil, :tag :tt, :content ["const&"]} "-qualified pointers to members"]}
+               "\n"
+               {:type    :element,
+                :attrs   nil,
+                :tag     :td,
+                :content [{:type :element, :attrs {:href "http://wg21.link/p0704r1"}, :tag :a, :content ["P0704R1"]}]}
+               "\n"
+               {:type :element, :attrs {:class "full", :align "center"}, :tag :td, :content ["Clang 6"]}
+               "\n"])
+
+(def content2 ["\n"
+               {:type    :element,
+                :attrs   {:rowspan "2"},
+                :tag     :td,
+                :content [{:type :element, :attrs nil, :tag :tt, :content ["__VA_OPT__"]}
+                          " for preprocessor comma elision"]}
+               "\n"
+               {:type    :element,
+                :attrs   nil,
+                :tag     :td,
+                :content [{:type :element, :attrs {:href "http://wg21.link/p0306r4"}, :tag :a, :content ["P0306R4"]}]}
+               "\n"
+               {:type :element, :attrs {:class "full", :align "center"}, :tag :td, :content ["Clang 6"]}
+               "\n"])
+
+(deftest content-processors-test
+  (is (= (extract-content content0)
+         ["Default member initializers for bit-fields" "P0683R1" "Clang 6"]))
+  (is (= (extract-content content1)
+         ["const&-qualified pointers to members" "P0704R1" "Clang 6"]))
+  (is (= (extract-content content2)
+         ["__VA_OPT__ for preprocessor comma elision" "P0306R4" "Clang 6"]))
+  (is (= 1 (get-rows-count content0)))
+  (is (= 1 (get-rows-count content1)))
+  (is (= 2 (get-rows-count content2)))
+  (is (= (extract-url content0) "http://wg21.link/p0683r1"))
+  (is (= (extract-url content1) "http://wg21.link/p0704r1"))
+  (is (= (extract-url content2) "http://wg21.link/p0306r4")))
+
+(deftest table-parsing-test
+  (let [tables (load-tables (load-test-page clang-status-test-page))
+        cxx20  (process-table (nth tables cxx-20-table-nr))]
+    (is (= (count cxx20) 12))
+    (has-keys (first cxx20) #{:id :link :title :tags})
+    (is (contains? (into #{} cxx20)
+                   {:id "P0482R6", :title "P0482R6: char8_t is available since Clang 7 (11)", :link "http://wg21.link/p0482r6", :tags ["c++" "c++20" "clang" "P0482R6"]}))))
+
+(deftest test-data-provider
+  (let [already-posted #{"P0482R6" "P0722R3" "P0683R1"}
+        dp (get-data-provider already-posted)
+        features (map #(:id %) (i/load-news dp))]
+    (is (empty? (set/intersection already-posted (into #{} (map #(:id %) features)))))))
+
+;(run-tests 'news-bot.compiler-features)

--- a/test/news_bot/test_utils.clj
+++ b/test/news_bot/test_utils.clj
@@ -48,4 +48,5 @@
 (def overload-test-page "test/data/overload/overload.html")
 (def boost-test-page "test/data/boost/Boost News.htm")
 (def cmake-test-page "test/data/cmake/cmake.html")
+(def clang-status-test-page "test/data/compiler_status/cxx_status.html")
 (def bucket-name "localstack-test-bucket")


### PR DESCRIPTION
- parse https://clang.llvm.org/cxx_status.html page;
- post updates if new proposal had implemented.